### PR TITLE
style: format code with prettier

### DIFF
--- a/src/main/resources/templates/components/nav.html
+++ b/src/main/resources/templates/components/nav.html
@@ -26,7 +26,7 @@
                         class="lucide lucide-user-icon lucide-user"
                     >
                         <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-                            <circle cx="12" cy="7" r="4" /></svg
+                        <circle cx="12" cy="7" r="4" /></svg
                     ><span sec:authentication="principal.username"></span>
                 </p>
 

--- a/src/main/resources/templates/pages/admin/grade-edit.html
+++ b/src/main/resources/templates/pages/admin/grade-edit.html
@@ -1,82 +1,126 @@
 <th:block
-        layout:decorate="~{layouts/main}"
-        xmlns:th="http://www.thymeleaf.org"
-        xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+    layout:decorate="~{layouts/main}"
+    xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 >
-  <th:block layout:fragment="content">
-
-    <div class="my-12">
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <p class="text-sm text-gray-600" th:text="${gym.name}">Gym Name</p>
-          <h2 class="text-2xl font-semibold" th:text="${grade.id} != null ? 'Edit Grade' : 'New Grade'">Edit Grade</h2>
-        </div>
-        <a th:href="${grade.id} != null ?
+    <th:block layout:fragment="content">
+        <div class="my-12">
+            <div class="flex items-center justify-between mb-6">
+                <div>
+                    <p class="text-sm text-gray-600" th:text="${gym.name}">
+                        Gym Name
+                    </p>
+                    <h2
+                        class="text-2xl font-semibold"
+                        th:text="${grade.id} != null ? 'Edit Grade' : 'New Grade'"
+                    >
+                        Edit Grade
+                    </h2>
+                </div>
+                <a
+                    th:href="${grade.id} != null ?
                      @{/admin/gyms/{gymId}/grades/{gradeId}(gymId=${gym.id}, gradeId=${grade.id})} :
                      @{/admin/gyms/{gymId}(gymId=${gym.id})}"
-           class="px-3 py-2 border rounded">Back</a>
-      </div>
+                    class="px-3 py-2 border rounded"
+                    >Back</a
+                >
+            </div>
 
-      <form th:action="${grade.id} != null ?
+            <form
+                th:action="${grade.id} != null ?
                         @{/admin/gyms/{gymId}/grades/{gradeId}(gymId=${gym.id}, gradeId=${grade.id})} :
                         @{/admin/gyms/{gymId}/grades(gymId=${gym.id})}"
-            th:object="${grade}"
-            method="post"
-            class="space-y-6">
-        <input type="hidden" name="_method" th:value="${grade.id} != null ? 'put' : 'post'"/>
+                th:object="${grade}"
+                method="post"
+                class="space-y-6"
+            >
+                <input
+                    type="hidden"
+                    name="_method"
+                    th:value="${grade.id} != null ? 'put' : 'post'"
+                />
 
-        <div>
-          <label class="block font-medium">Name</label>
-          <input th:field="*{name}" class="border w-full p-2 rounded"/>
-          <p th:if="${#fields.hasErrors('name')}"
-             th:errors="*{name}"
-             class="text-red-600 text-sm mt-1">
-          </p>
-        </div>
+                <div>
+                    <label class="block font-medium">Name</label>
+                    <input
+                        th:field="*{name}"
+                        class="border w-full p-2 rounded"
+                    />
+                    <p
+                        th:if="${#fields.hasErrors('name')}"
+                        th:errors="*{name}"
+                        class="text-red-600 text-sm mt-1"
+                    ></p>
+                </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <label class="block font-medium">V-Scale</label>
-            <input th:field="*{vScale}" class="border w-full p-2 rounded"/>
-            <p th:if="${#fields.hasErrors('vScale')}"
-               th:errors="*{vScale}"
-               class="text-red-600 text-sm mt-1">
-            </p>
-          </div>
-          <div>
-            <label class="block font-medium">Font-Scale</label>
-            <input th:field="*{fontScale}" class="border w-full p-2 rounded"/>
-            <p th:if="${#fields.hasErrors('fontScale')}"
-               th:errors="*{fontScale}"
-               class="text-red-600 text-sm mt-1">
-            </p>
-          </div>
-        </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block font-medium">V-Scale</label>
+                        <input
+                            th:field="*{vScale}"
+                            class="border w-full p-2 rounded"
+                        />
+                        <p
+                            th:if="${#fields.hasErrors('vScale')}"
+                            th:errors="*{vScale}"
+                            class="text-red-600 text-sm mt-1"
+                        ></p>
+                    </div>
+                    <div>
+                        <label class="block font-medium">Font-Scale</label>
+                        <input
+                            th:field="*{fontScale}"
+                            class="border w-full p-2 rounded"
+                        />
+                        <p
+                            th:if="${#fields.hasErrors('fontScale')}"
+                            th:errors="*{fontScale}"
+                            class="text-red-600 text-sm mt-1"
+                        ></p>
+                    </div>
+                </div>
 
-        <div>
-          <label class="block font-medium">Description</label>
-          <textarea th:field="*{description}" class="border w-full p-2 rounded" rows="4"></textarea>
-        </div>
+                <div>
+                    <label class="block font-medium">Description</label>
+                    <textarea
+                        th:field="*{description}"
+                        class="border w-full p-2 rounded"
+                        rows="4"
+                    ></textarea>
+                </div>
 
-        <div class="flex items-center space-x-3">
-          <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
-          <a th:href="${grade.id} != null ?
+                <div class="flex items-center space-x-3">
+                    <button
+                        type="submit"
+                        class="px-4 py-2 bg-blue-600 text-white rounded"
+                    >
+                        Save
+                    </button>
+                    <a
+                        th:href="${grade.id} != null ?
                       @{/admin/gyms/{gymId}/grades/{gradeId}(gymId=${gym.id}, gradeId=${grade.id})} :
                       @{/admin/gyms/{gymId}(gymId=${gym.id})}"
-             class="px-3 py-2 border rounded">
-            Cancel
-          </a>
+                        class="px-3 py-2 border rounded"
+                    >
+                        Cancel
+                    </a>
+                </div>
+            </form>
+
+            <div class="mt-8" th:if="${grade.id != null}">
+                <form
+                    th:action="@{/admin/gyms/{gymId}/grades/{gradeId}(gymId=${gym.id}, gradeId=${grade.id})}"
+                    method="post"
+                >
+                    <input type="hidden" name="_method" value="delete" />
+                    <button
+                        type="submit"
+                        class="px-3 py-2 text-white bg-red-600 rounded"
+                    >
+                        Delete Grade
+                    </button>
+                </form>
+            </div>
         </div>
-      </form>
-
-      <div class="mt-8" th:if="${grade.id != null}">
-        <form th:action="@{/admin/gyms/{gymId}/grades/{gradeId}(gymId=${gym.id}, gradeId=${grade.id})}"
-              method="post">
-          <input type="hidden" name="_method" value="delete"/>
-          <button type="submit" class="px-3 py-2 text-white bg-red-600 rounded">Delete Grade</button>
-        </form>
-      </div>
-    </div>
-
-  </th:block>
+    </th:block>
 </th:block>

--- a/src/main/resources/templates/pages/admin/grade.html
+++ b/src/main/resources/templates/pages/admin/grade.html
@@ -1,43 +1,66 @@
 <th:block
-        layout:decorate="~{layouts/main}"
-        xmlns:th="http://www.thymeleaf.org"
-        xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+    layout:decorate="~{layouts/main}"
+    xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 >
-  <th:block layout:fragment="content">
+    <th:block layout:fragment="content">
+        <div class="my-12 space-y-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm text-gray-600" th:text="${gym.name}">
+                        Gym Name
+                    </p>
+                    <h2
+                        class="text-2xl font-semibold"
+                        th:text="'Grade ' + ${grade.name}"
+                    >
+                        Grade Name
+                    </h2>
+                </div>
+                <div class="space-x-2">
+                    <a
+                        th:href="@{/admin/gyms/{gymId}/grades/{gradeId}/edit(gymId=${gym.id}, gradeId=${grade.id})}"
+                        class="px-3 py-2 bg-blue-600 text-white rounded"
+                        >Edit</a
+                    >
+                    <a
+                        th:href="@{/admin/gyms/{gymId}(gymId=${gym.id})}"
+                        class="px-3 py-2 border rounded"
+                        >Back</a
+                    >
+                </div>
+            </div>
 
-    <div class="my-12 space-y-6">
-      <div class="flex items-center justify-between">
-        <div>
-          <p class="text-sm text-gray-600" th:text="${gym.name}">Gym Name</p>
-          <h2 class="text-2xl font-semibold" th:text="'Grade ' + ${grade.name}">Grade Name</h2>
-        </div>
-        <div class="space-x-2">
-          <a th:href="@{/admin/gyms/{gymId}/grades/{gradeId}/edit(gymId=${gym.id}, gradeId=${grade.id})}"
-             class="px-3 py-2 bg-blue-600 text-white rounded">Edit</a>
-          <a th:href="@{/admin/gyms/{gymId}(gymId=${gym.id})}"
-             class="px-3 py-2 border rounded">Back</a>
-        </div>
-      </div>
+            <div class="border rounded p-6 space-y-4">
+                <div>
+                    <h3 class="text-lg font-semibold mb-1">Description</h3>
+                    <p
+                        th:text="${grade.description != null && !grade.description.isEmpty() ? grade.description : 'No description provided.'}"
+                        class="text-gray-700"
+                    ></p>
+                </div>
 
-      <div class="border rounded p-6 space-y-4">
-        <div>
-          <h3 class="text-lg font-semibold mb-1">Description</h3>
-          <p th:text="${grade.description != null && !grade.description.isEmpty() ? grade.description : 'No description provided.'}"
-             class="text-gray-700"></p>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="border rounded p-4">
+                        <p class="text-sm text-gray-600">V-Scale</p>
+                        <p
+                            class="text-lg font-semibold"
+                            th:text="${grade.vScale}"
+                        >
+                            V0
+                        </p>
+                    </div>
+                    <div class="border rounded p-4">
+                        <p class="text-sm text-gray-600">Font-Scale</p>
+                        <p
+                            class="text-lg font-semibold"
+                            th:text="${grade.fontScale}"
+                        >
+                            4
+                        </p>
+                    </div>
+                </div>
+            </div>
         </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="border rounded p-4">
-            <p class="text-sm text-gray-600">V-Scale</p>
-            <p class="text-lg font-semibold" th:text="${grade.vScale}">V0</p>
-          </div>
-          <div class="border rounded p-4">
-            <p class="text-sm text-gray-600">Font-Scale</p>
-            <p class="text-lg font-semibold" th:text="${grade.fontScale}">4</p>
-          </div>
-        </div>
-      </div>
-    </div>
-
-  </th:block>
+    </th:block>
 </th:block>

--- a/src/main/resources/templates/pages/admin/gym.html
+++ b/src/main/resources/templates/pages/admin/gym.html
@@ -1,82 +1,108 @@
 <th:block
-        layout:decorate="~{layouts/main}"
-        xmlns:th="http://www.thymeleaf.org"
-        xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+    layout:decorate="~{layouts/main}"
+    xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 >
-  <th:block layout:fragment="content">
+    <th:block layout:fragment="content">
+        <div class="my-12">
+            <h2 th:text="${gym.name}" class="text-2xl mb-6"></h2>
+            <p th:text="${gym.street}" class="mt-2"></p>
+            <p th:text="${gym.city}" class="mt-2"></p>
+            <p th:text="${gym.email}" class="mt-2"></p>
 
-    <div class="my-12">
-      <h2 th:text="${gym.name}"  class="text-2xl mb-6"></h2>
-      <p th:text="${gym.street}" class="mt-2"></p>
-      <p th:text="${gym.city}" class="mt-2"></p>
-      <p th:text="${gym.email}" class="mt-2"></p>
+            <div class="mt-8">
+                <div class="flex items-center justify-between mb-4">
+                    <h3 class="text-xl">Sectors</h3>
+                    <a
+                        th:href="@{/admin/gyms/{gymId}/sectors/new(gymId=${gym.id})}"
+                        class="px-3 py-1 bg-blue-600 text-white rounded"
+                    >
+                        Add Sector
+                    </a>
+                </div>
 
-      <div class="mt-8">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="text-xl">Sectors</h3>
-          <a th:href="@{/admin/gyms/{gymId}/sectors/new(gymId=${gym.id})}"
-             class="px-3 py-1 bg-blue-600 text-white rounded">
-            Add Sector
-          </a>
+                <table class="min-w-full border">
+                    <thead class="bg-gray-100">
+                        <tr>
+                            <th class="px-4 py-2 text-left">Name</th>
+                            <th class="px-4 py-2 text-left">Description</th>
+                            <th class="px-4 py-2 text-left">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr th:each="sector : ${gym.sectors}">
+                            <td class="px-4 py-2" th:text="${sector.name}">
+                                Sector Name
+                            </td>
+                            <td
+                                class="px-4 py-2"
+                                th:text="${sector.description}"
+                            >
+                                Description
+                            </td>
+                            <td class="px-4 py-2">
+                                <a
+                                    th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
+                                    class="text-blue-600 hover:underline"
+                                    >View</a
+                                >
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="mt-8">
+                <div class="flex items-center justify-between mb-4">
+                    <h3 class="text-xl">Grades</h3>
+                    <a
+                        th:href="@{/admin/gyms/{gymId}/grades/new(gymId=${gym.id})}"
+                        class="px-3 py-1 bg-blue-600 text-white rounded"
+                    >
+                        Add Grade
+                    </a>
+                </div>
+                <table class="min-w-full border">
+                    <thead class="bg-gray-100">
+                        <tr>
+                            <th class="px-4 py-2 text-left">Name</th>
+                            <th class="px-4 py-2 text-left">V-Scale</th>
+                            <th class="px-4 py-2 text-left">Font-Scale</th>
+                            <th class="px-4 py-2 text-left">Description</th>
+                            <th class="px-4 py-2 text-left">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr th:if="${#lists.isEmpty(grades)}">
+                            <td colspan="5" class="px-4 py-3 text-gray-600">
+                                No grades added yet.
+                            </td>
+                        </tr>
+                        <tr th:each="grade : ${grades}">
+                            <td class="px-4 py-2" th:text="${grade.name}">1</td>
+                            <td class="px-4 py-2" th:text="${grade.vScale}">
+                                V0
+                            </td>
+                            <td class="px-4 py-2" th:text="${grade.fontScale}">
+                                4
+                            </td>
+                            <td
+                                class="px-4 py-2"
+                                th:text="${grade.description}"
+                            >
+                                Description
+                            </td>
+                            <td class="px-4 py-2">
+                                <a
+                                    th:href="@{/admin/gyms/{gymId}/grades/{gradeId}(gymId=${gym.id}, gradeId=${grade.id})}"
+                                    class="text-blue-600 hover:underline"
+                                    >View</a
+                                >
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
-
-        <table class="min-w-full border">
-          <thead class="bg-gray-100">
-          <tr>
-            <th class="px-4 py-2 text-left">Name</th>
-            <th class="px-4 py-2 text-left">Description</th>
-            <th class="px-4 py-2 text-left">Actions</th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr th:each="sector : ${gym.sectors}">
-            <td class="px-4 py-2" th:text="${sector.name}">Sector Name</td>
-            <td class="px-4 py-2" th:text="${sector.description}">Description</td>
-            <td class="px-4 py-2">
-              <a th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
-                 class="text-blue-600 hover:underline">View</a>
-            </td>
-          </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="mt-8">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="text-xl">Grades</h3>
-          <a th:href="@{/admin/gyms/{gymId}/grades/new(gymId=${gym.id})}"
-             class="px-3 py-1 bg-blue-600 text-white rounded">
-            Add Grade
-          </a>
-        </div>
-        <table class="min-w-full border">
-          <thead class="bg-gray-100">
-          <tr>
-            <th class="px-4 py-2 text-left">Name</th>
-            <th class="px-4 py-2 text-left">V-Scale</th>
-            <th class="px-4 py-2 text-left">Font-Scale</th>
-            <th class="px-4 py-2 text-left">Description</th>
-            <th class="px-4 py-2 text-left">Actions</th>
-          </tr>
-          </thead>
-          <tbody>
-          <tr th:if="${#lists.isEmpty(grades)}">
-            <td colspan="5" class="px-4 py-3 text-gray-600">No grades added yet.</td>
-          </tr>
-          <tr th:each="grade : ${grades}">
-            <td class="px-4 py-2" th:text="${grade.name}">1</td>
-            <td class="px-4 py-2" th:text="${grade.vScale}">V0</td>
-            <td class="px-4 py-2" th:text="${grade.fontScale}">4</td>
-            <td class="px-4 py-2" th:text="${grade.description}">Description</td>
-            <td class="px-4 py-2">
-              <a th:href="@{/admin/gyms/{gymId}/grades/{gradeId}(gymId=${gym.id}, gradeId=${grade.id})}"
-                 class="text-blue-600 hover:underline">View</a>
-            </td>
-          </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-  </th:block>
+    </th:block>
 </th:block>

--- a/src/main/resources/templates/pages/admin/gyms.html
+++ b/src/main/resources/templates/pages/admin/gyms.html
@@ -1,15 +1,13 @@
 <th:block
-        layout:decorate="~{layouts/main}"
-        xmlns:th="http://www.thymeleaf.org"
-        xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+    layout:decorate="~{layouts/main}"
+    xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 >
     <th:block layout:fragment="content">
-
         <div class="my-12">
             <h2 class="text-2xl mb-6">Gyms</h2>
 
             <div class="grid grid-cols-3 gap-8">
-
                 <!-- Existing gyms -->
                 <div th:each="gym : ${gyms}" class="text-center">
                     <a th:href="@{/admin/gyms/{id}(id=${gym.id})}">
@@ -17,54 +15,70 @@
                     </a>
 
                     <!-- Delete Button -->
-                    <form th:action="@{/admin/gyms/{id}(id=${gym.id})}" method="post" th:object="${gym}" onsubmit="return confirm('Delete Gym?');">
-                        <input type="hidden" name="_method" value="delete"/>
-                        <button type="submit" class="text-red-600 ml-4 hover:text-red-800">
-                            &#128465; <!-- Papierkorb-Icon -->
+                    <form
+                        th:action="@{/admin/gyms/{id}(id=${gym.id})}"
+                        method="post"
+                        th:object="${gym}"
+                        onsubmit="return confirm('Delete Gym?');"
+                    >
+                        <input type="hidden" name="_method" value="delete" />
+                        <button
+                            type="submit"
+                            class="text-red-600 ml-4 hover:text-red-800"
+                        >
+                            &#128465;
+                            <!-- Papierkorb-Icon -->
                         </button>
                     </form>
                 </div>
-
             </div>
 
             <h2 class="text-2xl mb-6">Create Gym</h2>
 
-            <form th:action="@{/admin/gyms}" th:object="${newGym}" method="POST" class="space-y-4">
-
+            <form
+                th:action="@{/admin/gyms}"
+                th:object="${newGym}"
+                method="POST"
+                class="space-y-4"
+            >
                 <div>
                     <label>Name</label>
-                    <input th:field="*{name}" class="border w-full p-2"/>
-                    <p th:if="${#fields.hasErrors('name')}"
-                       th:errors="*{name}"
-                       class="text-red-600 text-sm mt-1">
-                    </p>
+                    <input th:field="*{name}" class="border w-full p-2" />
+                    <p
+                        th:if="${#fields.hasErrors('name')}"
+                        th:errors="*{name}"
+                        class="text-red-600 text-sm mt-1"
+                    ></p>
                 </div>
 
                 <div>
                     <label>Street</label>
-                    <input th:field="*{street}" class="border w-full p-2"/>
-                    <p th:if="${#fields.hasErrors('street')}"
-                       th:errors="*{street}"
-                       class="text-red-600 text-sm mt-1">
-                    </p>
+                    <input th:field="*{street}" class="border w-full p-2" />
+                    <p
+                        th:if="${#fields.hasErrors('street')}"
+                        th:errors="*{street}"
+                        class="text-red-600 text-sm mt-1"
+                    ></p>
                 </div>
 
                 <div>
                     <label>City</label>
-                    <input th:field="*{city}" class="border w-full p-2"/>
-                    <p th:if="${#fields.hasErrors('city')}"
-                       th:errors="*{city}"
-                       class="text-red-600 text-sm mt-1">
-                    </p>
+                    <input th:field="*{city}" class="border w-full p-2" />
+                    <p
+                        th:if="${#fields.hasErrors('city')}"
+                        th:errors="*{city}"
+                        class="text-red-600 text-sm mt-1"
+                    ></p>
                 </div>
 
                 <div>
                     <label>Email</label>
-                    <input th:field="*{email}" class="border w-full p-2"/>
-                    <p th:if="${#fields.hasErrors('email')}"
-                       th:errors="*{email}"
-                       class="text-red-600 text-sm mt-1">
-                    </p>
+                    <input th:field="*{email}" class="border w-full p-2" />
+                    <p
+                        th:if="${#fields.hasErrors('email')}"
+                        th:errors="*{email}"
+                        class="text-red-600 text-sm mt-1"
+                    ></p>
                 </div>
 
                 <button class="px-4 py-2 bg-blue-600 text-white rounded">
@@ -72,6 +86,5 @@
                 </button>
             </form>
         </div>
-
     </th:block>
 </th:block>

--- a/src/main/resources/templates/pages/admin/sector-edit.html
+++ b/src/main/resources/templates/pages/admin/sector-edit.html
@@ -1,73 +1,121 @@
 <th:block
-        layout:decorate="~{layouts/main}"
-        xmlns:th="http://www.thymeleaf.org"
-        xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+    layout:decorate="~{layouts/main}"
+    xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 >
-  <th:block layout:fragment="content">
+    <th:block layout:fragment="content">
+        <div class="my-12">
+            <div class="flex items-center justify-between mb-6">
+                <div>
+                    <p class="text-sm text-gray-600" th:text="${gym.name}">
+                        Gym Name
+                    </p>
+                    <h2
+                        class="text-2xl font-semibold"
+                        th:text="${sector.id} != null ? 'Edit Sector' : 'New Sector'"
+                    >
+                        Edit Sector
+                    </h2>
+                </div>
+                <a
+                    th:href="@{/admin/gyms/{gymId}(gymId=${gym.id})}"
+                    class="px-3 py-2 border rounded"
+                    >Back</a
+                >
+            </div>
 
-    <div class="my-12">
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <p class="text-sm text-gray-600" th:text="${gym.name}">Gym Name</p>
-          <h2 class="text-2xl font-semibold" th:text="${sector.id} != null ? 'Edit Sector' : 'New Sector'">Edit Sector</h2>
-        </div>
-        <a th:href="@{/admin/gyms/{gymId}(gymId=${gym.id})}" class="px-3 py-2 border rounded">Back</a>
-      </div>
-
-      <form th:action="${sector.id} != null ?
+            <form
+                th:action="${sector.id} != null ?
                         @{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})} :
                         @{/admin/gyms/{gymId}/sectors(gymId=${gym.id})}"
-            th:object="${sector}"
-            method="post"
-            class="space-y-6"
-      >
-        <input type="hidden" name="_method" th:value="${sector.id} != null ? 'put' : 'post'"/>
+                th:object="${sector}"
+                method="post"
+                class="space-y-6"
+            >
+                <input
+                    type="hidden"
+                    name="_method"
+                    th:value="${sector.id} != null ? 'put' : 'post'"
+                />
 
-        <div>
-          <label class="block font-medium">Name</label>
-          <input th:field="*{name}" class="border w-full p-2 rounded"/>
-          <p th:if="${#fields.hasErrors('name')}"
-             th:errors="*{name}"
-             class="text-red-600 text-sm mt-1">
-          </p>
+                <div>
+                    <label class="block font-medium">Name</label>
+                    <input
+                        th:field="*{name}"
+                        class="border w-full p-2 rounded"
+                    />
+                    <p
+                        th:if="${#fields.hasErrors('name')}"
+                        th:errors="*{name}"
+                        class="text-red-600 text-sm mt-1"
+                    ></p>
+                </div>
+
+                <div>
+                    <label class="block font-medium">Description</label>
+                    <textarea
+                        th:field="*{description}"
+                        class="border w-full p-2 rounded"
+                        rows="4"
+                    ></textarea>
+                </div>
+
+                <div class="space-y-2">
+                    <label class="block font-medium">Image</label>
+                    <img
+                        th:src="${sector.imagePath}"
+                        alt="Sector image"
+                        class="w-full h-48 object-cover rounded bg-gray-100"
+                    />
+                    <div class="flex space-x-2">
+                        <button
+                            type="button"
+                            class="px-3 py-2 border rounded bg-gray-100 cursor-not-allowed"
+                            disabled
+                        >
+                            Upload Image (coming soon)
+                        </button>
+                        <button
+                            type="button"
+                            class="px-3 py-2 border rounded bg-gray-100 cursor-not-allowed"
+                            disabled
+                        >
+                            Remove Image (coming soon)
+                        </button>
+                    </div>
+                </div>
+
+                <div class="flex items-center space-x-3">
+                    <button
+                        type="submit"
+                        class="px-4 py-2 bg-blue-600 text-white rounded"
+                    >
+                        Save
+                    </button>
+                    <a
+                        th:if="${sector.id != null}"
+                        th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
+                        class="px-3 py-2 border rounded"
+                    >
+                        Cancel
+                    </a>
+                </div>
+            </form>
+
+            <div class="mt-8" th:if="${sector.id != null}">
+                <form
+                    th:action="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
+                    method="post"
+                >
+                    <input type="hidden" name="_method" value="delete" />
+                    <button
+                        type="submit"
+                        class="px-3 py-2 text-white bg-red-600 rounded"
+                    >
+                        Delete Sector
+                    </button>
+                </form>
+            </div>
         </div>
-
-        <div>
-          <label class="block font-medium">Description</label>
-          <textarea th:field="*{description}" class="border w-full p-2 rounded" rows="4"></textarea>
-        </div>
-
-        <div class="space-y-2">
-          <label class="block font-medium">Image</label>
-          <img th:src="${sector.imagePath}" alt="Sector image" class="w-full h-48 object-cover rounded bg-gray-100">
-          <div class="flex space-x-2">
-            <button type="button" class="px-3 py-2 border rounded bg-gray-100 cursor-not-allowed" disabled>
-              Upload Image (coming soon)
-            </button>
-            <button type="button" class="px-3 py-2 border rounded bg-gray-100 cursor-not-allowed" disabled>
-              Remove Image (coming soon)
-            </button>
-          </div>
-        </div>
-
-        <div class="flex items-center space-x-3">
-          <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
-          <a th:if="${sector.id != null}"
-             th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
-             class="px-3 py-2 border rounded">
-            Cancel
-          </a>
-        </div>
-      </form>
-
-      <div class="mt-8" th:if="${sector.id != null}">
-        <form th:action="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
-              method="post">
-          <input type="hidden" name="_method" value="delete"/>
-          <button type="submit" class="px-3 py-2 text-white bg-red-600 rounded">Delete Sector</button>
-        </form>
-      </div>
-    </div>
-
-  </th:block>
+    </th:block>
 </th:block>

--- a/src/main/resources/templates/pages/admin/sector.html
+++ b/src/main/resources/templates/pages/admin/sector.html
@@ -1,36 +1,51 @@
 <th:block
-        layout:decorate="~{layouts/main}"
-        xmlns:th="http://www.thymeleaf.org"
-        xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+    layout:decorate="~{layouts/main}"
+    xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 >
-  <th:block layout:fragment="content">
+    <th:block layout:fragment="content">
+        <div class="my-12 space-y-6">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm text-gray-600" th:text="${gym.name}">
+                        Gym Name
+                    </p>
+                    <h2 class="text-2xl font-semibold" th:text="${sector.name}">
+                        Sector Name
+                    </h2>
+                </div>
+                <div class="space-x-2">
+                    <a
+                        th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}/edit(gymId=${gym.id}, sectorId=${sector.id})}"
+                        class="px-3 py-2 bg-blue-600 text-white rounded"
+                        >Edit</a
+                    >
+                    <a
+                        th:href="@{/admin/gyms/{gymId}(gymId=${gym.id})}"
+                        class="px-3 py-2 border rounded"
+                        >Back</a
+                    >
+                </div>
+            </div>
 
-    <div class="my-12 space-y-6">
-      <div class="flex items-center justify-between">
-        <div>
-          <p class="text-sm text-gray-600" th:text="${gym.name}">Gym Name</p>
-          <h2 class="text-2xl font-semibold" th:text="${sector.name}">Sector Name</h2>
+            <div
+                class="border rounded p-6 grid grid-cols-1 md:grid-cols-2 gap-6"
+            >
+                <div>
+                    <img
+                        th:src="${sector.imagePath}"
+                        alt="Sector image"
+                        class="w-full h-64 object-cover rounded bg-gray-100"
+                    />
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold mb-2">Description</h3>
+                    <p
+                        th:text="${sector.description != null ? sector.description : 'No description provided.'}"
+                        class="text-gray-700"
+                    ></p>
+                </div>
+            </div>
         </div>
-        <div class="space-x-2">
-          <a th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}/edit(gymId=${gym.id}, sectorId=${sector.id})}"
-             class="px-3 py-2 bg-blue-600 text-white rounded">Edit</a>
-          <a th:href="@{/admin/gyms/{gymId}(gymId=${gym.id})}"
-             class="px-3 py-2 border rounded">Back</a>
-        </div>
-      </div>
-
-      <div class="border rounded p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div>
-          <img th:src="${sector.imagePath}" alt="Sector image" class="w-full h-64 object-cover rounded bg-gray-100">
-        </div>
-        <div>
-          <h3 class="text-lg font-semibold mb-2">Description</h3>
-          <p th:text="${sector.description != null ? sector.description : 'No description provided.'}"
-             class="text-gray-700"></p>
-        </div>
-      </div>
-
-    </div>
-
-  </th:block>
+    </th:block>
 </th:block>

--- a/src/main/resources/templates/pages/error.html
+++ b/src/main/resources/templates/pages/error.html
@@ -7,19 +7,34 @@
         <main class="my-16 container mx-auto space-y-6">
             <section class="card bg-secondary-background p-6 space-y-4">
                 <div class="space-y-2">
-                    <p class="text-sm text-muted" th:text="${timestamp}">2025-01-01T00:00:00Z</p>
+                    <p class="text-sm text-muted" th:text="${timestamp}">
+                        2025-01-01T00:00:00Z
+                    </p>
                     <h1 class="text-2xl font-bold">
                         <span th:text="'Error ' + ${status}">Error 500</span>
-                        <span class="text-muted" th:text="${error}">Internal Server Error</span>
+                        <span class="text-muted" th:text="${error}"
+                            >Internal Server Error</span
+                        >
                     </h1>
                 </div>
 
                 <p th:text="${message}">Something went wrong.</p>
-                <p class="text-sm text-muted" th:if="${path}" th:text="'Path: ' + ${path}">Path: /some-path</p>
+                <p
+                    class="text-sm text-muted"
+                    th:if="${path}"
+                    th:text="'Path: ' + ${path}"
+                >
+                    Path: /some-path
+                </p>
 
                 <div th:if="${trace}" class="space-y-2">
                     <h2 class="text-lg font-semibold">Stacktrace (dev only)</h2>
-                    <pre class="overflow-auto p-4 bg-surface text-sm border rounded" th:text="${trace}">Trace goes here</pre>
+                    <pre
+                        class="overflow-auto p-4 bg-surface text-sm border rounded"
+                        th:text="${trace}"
+                    >
+Trace goes here</pre
+                    >
                 </div>
             </section>
         </main>


### PR DESCRIPTION
[Prettier](https://prettier.io/) ist ein code formatter, der quasi Industriestandard ist HTML, CSS und JS formatiert. [Installation ist super easy](https://prettier.io/docs/install). Ich hab dann in vscode auch noch eingestellt, dass er automatisch beim speichern formatiert, dann muss man sich da gar keine Gedanken mehr drüber machen. Für IntelliJ bin ich mir nicht sicher aber ich denke da wird's das auch geben. 

Die PR ist halt jetzt riesig weil alle Dateien formatiert wurden...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reformats Thymeleaf templates (nav, admin gym/sector/grade pages, and error page) for consistent indentation and markup with no functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b56951c75eafa99f59946228009eaee80dca00ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->