### PR TITLE
feat: align sector admin views with boulder layout

### DIFF
--- a/src/main/java/de/othr/crusher/controller/SectorController.java
+++ b/src/main/java/de/othr/crusher/controller/SectorController.java
@@ -83,7 +83,7 @@ public class SectorController {
 
         model.addAttribute("gym", gym);
         model.addAttribute("sector", sector);
-        return "pages/admin/sector-edit";
+        return "pages/admin/sector-new";
     }
 
     /**
@@ -126,8 +126,11 @@ public class SectorController {
         GymEntity gym = findGymOrThrow(gymId);
 
         if (result.hasErrors()) {
+            if (sector.getImagePath() == null || sector.getImagePath().isBlank()) {
+                sector.setImagePath(DEFAULT_IMAGE_PATH);
+            }
             model.addAttribute("gym", gym);
-            return "pages/admin/sector-edit";
+            return "pages/admin/sector-new";
         }
 
         sector.setGym(gym);
@@ -162,6 +165,10 @@ public class SectorController {
         if (result.hasErrors()) {
             formSector.setId(sector.getId());
             formSector.setGym(gym);
+            if (formSector.getImagePath() == null || formSector.getImagePath().isBlank()) {
+                formSector.setImagePath(
+                        sector.getImagePath() != null ? sector.getImagePath() : DEFAULT_IMAGE_PATH);
+            }
             model.addAttribute("gym", gym);
             model.addAttribute("sector", formSector);
             return "pages/admin/sector-edit";

--- a/src/main/resources/templates/components/sector-form.html
+++ b/src/main/resources/templates/components/sector-form.html
@@ -1,0 +1,71 @@
+<form
+    th:fragment="sector-form(actionUrl, sector, gym)"
+    th:action="${actionUrl}"
+    th:object="${sector}"
+    method="post"
+    class="space-y-6"
+    xmlns:th="http://www.thymeleaf.org"
+>
+    <input
+        type="hidden"
+        name="_method"
+        th:value="${sector.id} != null ? 'put' : 'post'"
+    />
+
+    <div>
+        <label class="block font-medium mb-2">Name</label>
+        <input th:field="*{name}" class="border w-full p-2 rounded" />
+        <p
+            th:if="${#fields.hasErrors('name')}"
+            th:errors="*{name}"
+            class="text-red-600 text-sm mt-1"
+        ></p>
+    </div>
+
+    <div>
+        <label class="block font-medium mb-2">Description</label>
+        <textarea
+            th:field="*{description}"
+            class="border w-full p-2 rounded"
+            rows="4"
+        ></textarea>
+    </div>
+
+    <div class="space-y-2">
+        <label class="block font-medium">Image</label>
+        <img
+            th:src="${sector.imagePath}"
+            alt="Sector image"
+            class="w-full h-48 object-cover rounded bg-gray-100"
+        />
+        <div class="flex space-x-2">
+            <button
+                type="button"
+                class="px-3 py-2 border rounded bg-gray-100 cursor-not-allowed"
+                disabled
+            >
+                Upload Image (coming soon)
+            </button>
+            <button
+                type="button"
+                class="px-3 py-2 border rounded bg-gray-100 cursor-not-allowed"
+                disabled
+            >
+                Remove Image (coming soon)
+            </button>
+        </div>
+    </div>
+
+    <div class="flex items-center space-x-3">
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">
+            Save
+        </button>
+        <a
+            th:if="${sector.id != null}"
+            th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
+            class="px-3 py-2 border rounded"
+        >
+            Cancel
+        </a>
+    </div>
+</form>

--- a/src/main/resources/templates/pages/admin/sector-edit.html
+++ b/src/main/resources/templates/pages/admin/sector-edit.html
@@ -10,99 +10,26 @@
                     <p class="text-sm text-gray-600" th:text="${gym.name}">
                         Gym Name
                     </p>
-                    <h2
-                        class="text-2xl font-semibold"
-                        th:text="${sector.id} != null ? 'Edit Sector' : 'New Sector'"
-                    >
-                        Edit Sector
+                    <h2 class="text-2xl font-semibold" th:text="${sector.name}">
+                        Sector Name
                     </h2>
                 </div>
                 <a
-                    th:href="@{/admin/gyms/{gymId}(gymId=${gym.id})}"
+                    th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
                     class="px-3 py-2 border rounded"
-                    >Back</a
+                    >Back to Sector</a
                 >
             </div>
 
-            <form
-                th:action="${sector.id} != null ?
-                        @{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})} :
-                        @{/admin/gyms/{gymId}/sectors(gymId=${gym.id})}"
-                th:object="${sector}"
-                method="post"
-                class="space-y-6"
-            >
-                <input
-                    type="hidden"
-                    name="_method"
-                    th:value="${sector.id} != null ? 'put' : 'post'"
-                />
+            <th:block
+                th:replace="~{components/sector-form :: sector-form(
+                    @{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})},
+                    ${sector},
+                    ${gym}
+                )}"
+            ></th:block>
 
-                <div>
-                    <label class="block font-medium">Name</label>
-                    <input
-                        th:field="*{name}"
-                        class="border w-full p-2 rounded"
-                    />
-                    <p
-                        th:if="${#fields.hasErrors('name')}"
-                        th:errors="*{name}"
-                        class="text-red-600 text-sm mt-1"
-                    ></p>
-                </div>
-
-                <div>
-                    <label class="block font-medium">Description</label>
-                    <textarea
-                        th:field="*{description}"
-                        class="border w-full p-2 rounded"
-                        rows="4"
-                    ></textarea>
-                </div>
-
-                <div class="space-y-2">
-                    <label class="block font-medium">Image</label>
-                    <img
-                        th:src="${sector.imagePath}"
-                        alt="Sector image"
-                        class="w-full h-48 object-cover rounded bg-gray-100"
-                    />
-                    <div class="flex space-x-2">
-                        <button
-                            type="button"
-                            class="px-3 py-2 border rounded bg-gray-100 cursor-not-allowed"
-                            disabled
-                        >
-                            Upload Image (coming soon)
-                        </button>
-                        <button
-                            type="button"
-                            class="px-3 py-2 border rounded bg-gray-100 cursor-not-allowed"
-                            disabled
-                        >
-                            Remove Image (coming soon)
-                        </button>
-                    </div>
-                </div>
-
-                <div class="flex items-center space-x-3">
-                    <button
-                        type="submit"
-                        class="px-4 py-2 bg-blue-600 text-white rounded"
-                    >
-                        Save
-                    </button>
-                    <a
-                        th:if="${sector.id != null}"
-                        th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
-                        class="px-3 py-2 border rounded"
-                    >
-                        Cancel
-                    </a>
-                </div>
-            </form>
-
-            <div class="mt-8" th:if="${sector.id != null}">
+            <div class="mt-8">
                 <form
                     th:action="@{/admin/gyms/{gymId}/sectors/{sectorId}(gymId=${gym.id}, sectorId=${sector.id})}"
                     method="post"

--- a/src/main/resources/templates/pages/admin/sector-new.html
+++ b/src/main/resources/templates/pages/admin/sector-new.html
@@ -1,0 +1,31 @@
+<th:block
+    layout:decorate="~{layouts/main}"
+    xmlns:th="http://www.thymeleaf.org"
+    xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+>
+    <th:block layout:fragment="content">
+        <div class="my-12">
+            <div class="flex items-center justify-between mb-6">
+                <div>
+                    <p class="text-sm text-gray-600" th:text="${gym.name}">
+                        Gym Name
+                    </p>
+                    <h2 class="text-2xl font-semibold">New Sector</h2>
+                </div>
+                <a
+                    th:href="@{/admin/gyms/{gymId}(gymId=${gym.id})}"
+                    class="px-3 py-2 border rounded"
+                    >Back to Gym</a
+                >
+            </div>
+
+            <th:block
+                th:replace="~{components/sector-form :: sector-form(
+                    @{/admin/gyms/{gymId}/sectors(gymId=${gym.id})},
+                    ${sector},
+                    ${gym}
+                )}"
+            ></th:block>
+        </div>
+    </th:block>
+</th:block>

--- a/src/main/resources/templates/pages/admin/sector.html
+++ b/src/main/resources/templates/pages/admin/sector.html
@@ -4,7 +4,7 @@
     xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
 >
     <th:block layout:fragment="content">
-        <div class="my-12 space-y-6">
+        <div class="my-12 space-y-8">
             <div class="flex items-center justify-between">
                 <div>
                     <p class="text-sm text-gray-600" th:text="${gym.name}">
@@ -46,73 +46,85 @@
                     ></p>
                 </div>
             </div>
-        </div>
-        <div class="space-x-2">
-          <a th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}/edit(gymId=${gym.id}, sectorId=${sector.id})}"
-             class="px-3 py-2 bg-blue-600 text-white rounded">Edit</a>
-          <a th:href="@{/admin/gyms/{gymId}(gymId=${gym.id})}"
-             class="px-3 py-2 border rounded">Back</a>
-        </div>
-      </div>
 
-      <div class="border rounded p-6 grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div>
-          <img th:src="${sector.imagePath}" alt="Sector image" class="w-full h-64 object-cover rounded bg-gray-100">
-        </div>
-        <div>
-          <h3 class="text-lg font-semibold mb-2">Description</h3>
-          <p th:text="${sector.description != null ? sector.description : 'No description provided.'}"
-             class="text-gray-700"></p>
-        </div>
-      </div>
+            <div class="space-y-4">
+                <!-- Boulders Section -->
+                <div class="flex items-center justify-between">
+                    <h3 class="text-xl font-semibold">Boulders</h3>
+                    <a
+                        th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}/boulders/new(gymId=${gym.id}, sectorId=${sector.id})}"
+                        class="px-3 py-2 bg-blue-600 text-white rounded"
+                        >New Boulder</a
+                    >
+                </div>
 
-      <!-- Boulders Section -->
-      <div class="space-y-4">
-        <div class="flex items-center justify-between">
-          <h3 class="text-xl font-semibold">Boulders</h3>
-          <a th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}/boulders/new(gymId=${gym.id}, sectorId=${sector.id})}"
-             class="px-3 py-2 bg-blue-600 text-white rounded">New Boulder</a>
+                <div
+                    th:if="${boulders.isEmpty()}"
+                    class="border rounded p-6 text-center text-gray-600"
+                >
+                    No boulders in this sector yet.
+                </div>
+
+                <div
+                    th:unless="${boulders.isEmpty()}"
+                    class="border rounded overflow-hidden"
+                >
+                    <table class="w-full">
+                        <thead class="bg-gray-100 border-b">
+                            <tr>
+                                <th class="px-4 py-2 text-left font-semibold">
+                                    Color
+                                </th>
+                                <th class="px-4 py-2 text-left font-semibold">
+                                    Grade
+                                </th>
+                                <th class="px-4 py-2 text-left font-semibold">
+                                    Description
+                                </th>
+                                <th class="px-4 py-2 text-left font-semibold">
+                                    Actions
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr
+                                th:each="boulder : ${boulders}"
+                                class="border-b last:border-b-0 hover:bg-gray-50"
+                            >
+                                <td class="px-4 py-3">
+                                    <div class="flex items-center space-x-2">
+                                        <div
+                                            th:class="'w-6 h-6 rounded ' + ${boulder.color.cssColorClass}"
+                                        ></div>
+                                        <span
+                                            th:text="${boulder.color.displayName}"
+                                            >Color</span
+                                        >
+                                    </div>
+                                </td>
+                                <td class="px-4 py-3">
+                                    <span th:text="${boulder.grade.name}"
+                                        >Grade</span
+                                    >
+                                </td>
+                                <td
+                                    class="px-4 py-3"
+                                    th:text="${boulder.description}"
+                                >
+                                    Description
+                                </td>
+                                <td class="px-4 py-3">
+                                    <a
+                                        th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}/boulders/{boulderId}/edit(gymId=${gym.id}, sectorId=${sector.id}, boulderId=${boulder.id})}"
+                                        class="px-3 py-1 bg-blue-600 text-white text-sm rounded"
+                                        >Edit</a
+                                    >
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
-
-        <div th:if="${boulders.isEmpty()}" class="border rounded p-6 text-center text-gray-600">
-          No boulders in this sector yet.
-        </div>
-
-        <div th:unless="${boulders.isEmpty()}" class="border rounded overflow-hidden">
-          <table class="w-full">
-            <thead class="bg-gray-100 border-b">
-              <tr>
-                <th class="px-4 py-2 text-left font-semibold">Color</th>
-                <th class="px-4 py-2 text-left font-semibold">Grade</th>
-                <th class="px-4 py-2 text-left font-semibold">Description</th>
-                <th class="px-4 py-2 text-left font-semibold">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr th:each="boulder : ${boulders}" class="border-b last:border-b-0 hover:bg-gray-50">
-                <td class="px-4 py-3">
-                  <div class="flex items-center space-x-2">
-                    <div th:class="'w-6 h-6 rounded ' + ${boulder.color.cssColorClass}"></div>
-                    <span th:text="${boulder.color.displayName}">Color</span>
-                  </div>
-                </td>
-                <td class="px-4 py-3">
-                  <span th:text="${boulder.grade.name}">Grade</span>
-                </td>
-                <td class="px-4 py-3" th:text="${boulder.description}">
-                  Description
-                </td>
-                <td class="px-4 py-3">
-                  <a th:href="@{/admin/gyms/{gymId}/sectors/{sectorId}/boulders/{boulderId}/edit(gymId=${gym.id}, sectorId=${sector.id}, boulderId=${boulder.id})}"
-                     class="px-3 py-1 bg-blue-600 text-white text-sm rounded">Edit</a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-    </div>
-
-  </th:block>
+    </th:block>
 </th:block>


### PR DESCRIPTION
- Align sector admin views with the boulder layout: introduced a shared sector-form component and separate sector-new/sector-edit pages wired into the controller.
- Cleaned up the sector detail page to remove duplicate sections.
- Ensured sector form defaults the image path on validation errors and re-renders appropriately.
